### PR TITLE
Remove session created event

### DIFF
--- a/Sources/Event+Media.swift
+++ b/Sources/Event+Media.swift
@@ -26,7 +26,7 @@ extension Event {
 
     /// Returns tracker config associated with EVENT_SOURCE_TRACKER_REQUEST Event
     var trackerConfig: [String: Any]? {
-        guard source == MediaConstants.Media.EVENT_SOURCE_TRACKER_REQUEST else {
+        guard source == MediaConstants.Media.EVENT_SOURCE_CREATE_TRACKER else {
             return nil
         }
         return data?[MediaConstants.Tracker.EVENT_PARAM] as? [String: Any]

--- a/Sources/Media.swift
+++ b/Sources/Media.swift
@@ -43,7 +43,7 @@ public class Media: NSObject, Extension {
 
     /// Invoked when the Media extension has been registered by the `EventHub`
     public func onRegistered() {
-        registerListener(type: MediaConstants.Media.EVENT_TYPE, source: MediaConstants.Media.EVENT_SOURCE_TRACKER_REQUEST, listener: handleMediaTrackerRequest)
+        registerListener(type: MediaConstants.Media.EVENT_TYPE, source: MediaConstants.Media.EVENT_SOURCE_CREATE_TRACKER, listener: handleMediaTrackerRequest)
         registerListener(type: MediaConstants.Media.EVENT_TYPE, source: MediaConstants.Media.EVENT_SOURCE_TRACK_MEDIA, listener: handleMediaTrack)
         registerListener(type: EventType.configuration, source: EventSource.responseContent, listener: handleConfigurationResponseEvent)
         registerListener(type: EventType.edge, source: MediaConstants.Media.EVENT_SOURCE_MEDIA_EDGE_SESSION, listener: handleMediaEdgeSessionDetails)

--- a/Sources/MediaConstants.swift
+++ b/Sources/MediaConstants.swift
@@ -28,9 +28,9 @@ internal extension MediaConstants {
     }
 
     enum Media {
-        static let EVENT_TYPE = "com.adobe.eventtype.edgemedia"
-        static let EVENT_SOURCE_TRACKER_REQUEST = "com.adobe.eventsource.edgemedia.requesttracker"
-        static let EVENT_SOURCE_TRACK_MEDIA = "com.adobe.eventsource.edgemedia.trackmedia"
+        static let EVENT_TYPE = "com.adobe.eventType.edgeMedia"
+        static let EVENT_SOURCE_CREATE_TRACKER = "com.adobe.eventSource.createTracker"
+        static let EVENT_SOURCE_TRACK_MEDIA = "com.adobe.eventSource.trackMedia"
         static let EVENT_NAME_CREATE_TRACKER = "Media::CreateTrackerRequest"
         static let EVENT_NAME_TRACK_MEDIA = "Media::TrackMedia"
         static let EVENT_SOURCE_MEDIA_EDGE_SESSION = "media-analytics:new-session"

--- a/Sources/MediaConstants.swift
+++ b/Sources/MediaConstants.swift
@@ -31,10 +31,8 @@ internal extension MediaConstants {
         static let EVENT_TYPE = "com.adobe.eventtype.edgemedia"
         static let EVENT_SOURCE_TRACKER_REQUEST = "com.adobe.eventsource.edgemedia.requesttracker"
         static let EVENT_SOURCE_TRACK_MEDIA = "com.adobe.eventsource.edgemedia.trackmedia"
-        static let EVENT_SOURCE_SESSION_CREATED = "com.adobe.eventsource.edgemedia.sessioncreated"
         static let EVENT_NAME_CREATE_TRACKER = "Media::CreateTrackerRequest"
         static let EVENT_NAME_TRACK_MEDIA = "Media::TrackMedia"
-        static let EVENT_NAME_SESSION_CREATED = "Media::SessionCreated"
         static let EVENT_SOURCE_MEDIA_EDGE_SESSION = "media-analytics:new-session"
         static let EVENT_SOURCE_EDGE_ERROR_RESPONSE = "com.adobe.eventSource.errorResponseContent"
 

--- a/Sources/MediaPublicTracker.swift
+++ b/Sources/MediaPublicTracker.swift
@@ -47,7 +47,7 @@ class MediaPublicTracker: MediaTracker {
         ]
         let event = Event(name: MediaConstants.Media.EVENT_NAME_CREATE_TRACKER,
                           type: MediaConstants.Media.EVENT_TYPE,
-                          source: MediaConstants.Media.EVENT_SOURCE_TRACKER_REQUEST,
+                          source: MediaConstants.Media.EVENT_SOURCE_CREATE_TRACKER,
                           data: eventData)
 
         dispatch?(event)

--- a/Sources/MediaRealTimeSession.swift
+++ b/Sources/MediaRealTimeSession.swift
@@ -80,10 +80,9 @@ class MediaRealTimeSession: MediaSession {
             return
         }
 
-        // If valid backendSessionId is received dispatch the sessionCreated event and start processing the queued media events
+        // If valid backendSessionId is received start processing the queued media events
         if updateBackendSessionId(backendSessionId) {
             Log.trace(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - [Session (\(id)] Updating MediaEdge session with backendSessionId:(\(mediaBackendSessionId)).")
-            dispatchSessionCreatedEvent()
             tryDispatchExperienceEvent()
 
         } else {
@@ -247,24 +246,5 @@ class MediaRealTimeSession: MediaSession {
         self.mediaBackendSessionId = backendSessionId
 
         return true
-    }
-
-    /// Dispatches media session created event after receiving the backend session id.
-    private func dispatchSessionCreatedEvent() {
-        // Dispatch session created event
-        var eventData: [String: Any] = [:]
-        eventData[MediaConstants.Tracker.BACKEND_SESSION_ID] = mediaBackendSessionId
-
-        // Attach tracker session Id for debug
-        if trackerSessionId != nil {
-            eventData[MediaConstants.Tracker.SESSION_ID] = trackerSessionId
-        }
-
-        let sessionCreatedEvent = Event(name: MediaConstants.Media.EVENT_NAME_SESSION_CREATED,
-                                        type: MediaConstants.Media.EVENT_TYPE,
-                                        source: MediaConstants.Media.EVENT_SOURCE_SESSION_CREATED,
-                                        data: eventData)
-
-        self.dispatcher?(sessionCreatedEvent)
     }
 }

--- a/Tests/FunctionalTests/Scenarios/AdChapterPlayback.swift
+++ b/Tests/FunctionalTests/Scenarios/AdChapterPlayback.swift
@@ -77,7 +77,6 @@ class AdChapterPlayback: BaseScenarioTest {
 
         let expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfoWithDefaultPreroll.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: curSessionId), backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.adBreakStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: adBreakInfo.toMap()),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.adStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: adInfo.toMap(), metadata: adMetadata, mediaState: mediaState),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 0, ts: 0, backendSessionId: backendSessionId),

--- a/Tests/FunctionalTests/Scenarios/AdPlayback.swift
+++ b/Tests/FunctionalTests/Scenarios/AdPlayback.swift
@@ -62,7 +62,6 @@ class AdPlayback: BaseScenarioTest {
 
         let expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfo.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: curSessionId), backendSessionId: backendSessionId),
 
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.adBreakStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: adBreakInfo.toMap()),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.adStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: adInfo.toMap(), metadata: adMetadata, mediaState: mediaState),
@@ -118,7 +117,6 @@ class AdPlayback: BaseScenarioTest {
 
         let expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfo.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: curSessionId), backendSessionId: backendSessionId),
 
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.adBreakStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: adBreakInfo.toMap()),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.adStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: adInfo.toMap(), metadata: adMetadata, mediaState: mediaState),

--- a/Tests/FunctionalTests/Scenarios/ChapterPlayback.swift
+++ b/Tests/FunctionalTests/Scenarios/ChapterPlayback.swift
@@ -57,7 +57,6 @@ class ChapterPlayback: BaseScenarioTest {
 
         let expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfo.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: curSessionId), backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.chapterStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: chapterInfo.toMap(), metadata: chapterMetadata),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 0, ts: 0, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 1, ts: 1, backendSessionId: backendSessionId),
@@ -97,7 +96,6 @@ class ChapterPlayback: BaseScenarioTest {
 
         let expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfo.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: curSessionId), backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.chapterStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: chapterInfo.toMap(), metadata: chapterMetadata),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 0, ts: 0, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 1, ts: 1, backendSessionId: backendSessionId),

--- a/Tests/FunctionalTests/Scenarios/CustomError.swift
+++ b/Tests/FunctionalTests/Scenarios/CustomError.swift
@@ -53,7 +53,6 @@ class CustomError: BaseScenarioTest {
 
         let expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfoWithDefaultPreroll.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: curSessionId), backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 0, ts: 0, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 1, ts: 1, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.error, playhead: 5, ts: 5, backendSessionId: backendSessionId, info: errorInfo1),

--- a/Tests/FunctionalTests/Scenarios/CustomPingDuration.swift
+++ b/Tests/FunctionalTests/Scenarios/CustomPingDuration.swift
@@ -56,7 +56,6 @@ class CustomPingDuration: BaseScenarioTest {
 
         let expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfo.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: curSessionId), backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.adBreakStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: adBreakInfo.toMap()),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.adStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: adInfo.toMap(), metadata: adMetadata, mediaState: mediaState),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 0, ts: 0, backendSessionId: backendSessionId),
@@ -107,7 +106,6 @@ class CustomPingDuration: BaseScenarioTest {
 
         let expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfo.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: curSessionId), backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.adBreakStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: adBreakInfo.toMap()),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.adStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: adInfo.toMap(), metadata: adMetadata, mediaState: mediaState),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 0, ts: 0, backendSessionId: backendSessionId),

--- a/Tests/FunctionalTests/Scenarios/CustomStatePlayback.swift
+++ b/Tests/FunctionalTests/Scenarios/CustomStatePlayback.swift
@@ -57,7 +57,6 @@ class CustomStatePlayback: BaseScenarioTest {
 
         let expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfo.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: curSessionId), backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 0, ts: 0, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.statesUpdate, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: customStateInfo.toMap(), stateStart: true),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 1, ts: 1, backendSessionId: backendSessionId),
@@ -100,7 +99,6 @@ class CustomStatePlayback: BaseScenarioTest {
 
         let expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfo.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: curSessionId), backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 0, ts: 0, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.statesUpdate, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: customStateInfo.toMap(), stateStart: true),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 1, ts: 1, backendSessionId: backendSessionId),
@@ -147,7 +145,6 @@ class CustomStatePlayback: BaseScenarioTest {
 
         var expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfo.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: curSessionId), backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 0, ts: 0, backendSessionId: backendSessionId)
         ]
 

--- a/Tests/FunctionalTests/Scenarios/SimplePlayback.swift
+++ b/Tests/FunctionalTests/Scenarios/SimplePlayback.swift
@@ -50,7 +50,6 @@ class SimplePlayback: BaseScenarioTest {
 
         let expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfo.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: curSessionId), backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 0, ts: 0, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 1, ts: 1, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.pauseStart, playhead: 5, ts: 5, backendSessionId: backendSessionId),
@@ -89,7 +88,6 @@ class SimplePlayback: BaseScenarioTest {
 
         let expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfo.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: curSessionId), backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 0, ts: 0, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 1, ts: 1, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.pauseStart, playhead: 5, ts: 5, backendSessionId: backendSessionId),
@@ -131,7 +129,6 @@ class SimplePlayback: BaseScenarioTest {
 
         let expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfo.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: curSessionId), backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.bufferStart, playhead: 0, ts: 0, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 0, ts: 5, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 1, ts: 6, backendSessionId: backendSessionId),
@@ -174,7 +171,6 @@ class SimplePlayback: BaseScenarioTest {
 
         let expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfo.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: curSessionId), backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.pauseStart, playhead: 0, ts: 0, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 0, ts: 5, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 1, ts: 6, backendSessionId: backendSessionId),

--- a/Tests/FunctionalTests/Scenarios/SpecialAdPlayback.swift
+++ b/Tests/FunctionalTests/Scenarios/SpecialAdPlayback.swift
@@ -74,7 +74,6 @@ class SpecialAdPlayback: BaseScenarioTest {
 
         let expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfoWithDefaultPreroll.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: curSessionId), backendSessionId: backendSessionId),
 
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.adBreakStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: adBreakInfo.toMap()),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.ping, playhead: 0, ts: 10, backendSessionId: backendSessionId),
@@ -151,7 +150,6 @@ class SpecialAdPlayback: BaseScenarioTest {
 
         let expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfoWithDefaultPreroll.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: curSessionId), backendSessionId: backendSessionId),
 
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.adBreakStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: adBreakInfo.toMap()),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.adStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: adInfo.toMap(), metadata: adMetadata, mediaState: mediaState),
@@ -221,7 +219,6 @@ class SpecialAdPlayback: BaseScenarioTest {
 
         let expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfoWithDefaultPreroll.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: curSessionId), backendSessionId: backendSessionId),
 
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.bufferStart, playhead: 0, ts: 0, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.pauseStart, playhead: 0, ts: 5, backendSessionId: backendSessionId),

--- a/Tests/FunctionalTests/Scenarios/Timeout.swift
+++ b/Tests/FunctionalTests/Scenarios/Timeout.swift
@@ -45,7 +45,7 @@ class Timeout: BaseScenarioTest {
         wait()
 
         // mock sessionIDUpdate for restart sceario session2
-        mediaEventProcessorSpy.mockBackendSessionId(sessionId: sessionId2, sessionStartEvent: dispatchedEvents[8644], fakeBackendId: backendSessionId)
+        mediaEventProcessorSpy.mockBackendSessionId(sessionId: sessionId2, sessionStartEvent: dispatchedEvents[8643], fakeBackendId: backendSessionId)
 
         // wait for 20 seconds
         incrementTrackerTime(seconds: 20, updatePlayhead: true)
@@ -58,7 +58,6 @@ class Timeout: BaseScenarioTest {
 
         var expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfoWithDefaultPreroll.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: sessionId1), backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 0, ts: 0, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 1, ts: 1, backendSessionId: backendSessionId)
         ]
@@ -74,7 +73,6 @@ class Timeout: BaseScenarioTest {
 
         let expectedEventsSession2: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 86400, ts: 86400, backendSessionId: backendSessionId, info: resumedMediaInfo, metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: sessionId2), backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 86400, ts: 86400, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 86401, ts: 86401, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.ping, playhead: 86411, ts: 86411, backendSessionId: backendSessionId),
@@ -111,7 +109,6 @@ class Timeout: BaseScenarioTest {
 
         var expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfoWithDefaultPreroll.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: curSessionId), backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 0, ts: 0, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 1, ts: 1, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.pauseStart, playhead: 3, ts: 3, backendSessionId: backendSessionId)
@@ -158,7 +155,7 @@ class Timeout: BaseScenarioTest {
 
         wait()
         // mock sessionIDUpdate for restart sceario session2
-        mediaEventProcessorSpy.mockBackendSessionId(sessionId: sessionId2, sessionStartEvent: dispatchedEvents[187], fakeBackendId: backendSessionId)
+        mediaEventProcessorSpy.mockBackendSessionId(sessionId: sessionId2, sessionStartEvent: dispatchedEvents[186], fakeBackendId: backendSessionId)
         incrementTrackerTime(seconds: 3, updatePlayhead: true)
         mediaTracker.trackComplete()
 
@@ -166,7 +163,6 @@ class Timeout: BaseScenarioTest {
 
         var expectedEvents: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 0, ts: 0, backendSessionId: backendSessionId, info: mediaInfoWithDefaultPreroll.toMap(), metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: sessionId1), backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 0, ts: 0, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 1, ts: 1, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.pauseStart, playhead: 3, ts: 3, backendSessionId: backendSessionId)
@@ -199,7 +195,6 @@ class Timeout: BaseScenarioTest {
 
         let expectedEventsSession2: [Event] = [
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionStart, playhead: 3, ts: 1803, backendSessionId: backendSessionId, info: resumedMediaInfo, metadata: mediaMetadata, mediaState: mediaState),
-            EdgeEventHelper.generateSessionCreatedEvent(trackerSessionId: mediaEventProcessorSpy.getTrackerSessionId(sessionId: sessionId2), backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 3, ts: 1803, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.play, playhead: 4, ts: 1804, backendSessionId: backendSessionId),
             EdgeEventHelper.generateEdgeEvent(eventType: XDMMediaEventType.sessionComplete, playhead: 6, ts: 1806, backendSessionId: backendSessionId)

--- a/Tests/TestHelpers/EdgeEventHelper.swift
+++ b/Tests/TestHelpers/EdgeEventHelper.swift
@@ -306,16 +306,4 @@ class EdgeEventHelper {
                                    data: data)
         return mediaEdgeEvent
     }
-
-    static func generateSessionCreatedEvent(trackerSessionId: String, backendSessionId: String) -> Event {
-        var eventData: [String: Any] = [:]
-        eventData[MediaConstants.Tracker.BACKEND_SESSION_ID] = backendSessionId
-        eventData[MediaConstants.Tracker.SESSION_ID] = trackerSessionId
-
-        let sessionCreatedEvent = Event(name: "Media::SessionCreated",
-                                        type: "com.adobe.eventtype.edgemedia",
-                                        source: "com.adobe.eventsource.edgemedia.sessioncreated",
-                                        data: eventData)
-        return sessionCreatedEvent
-    }
 }

--- a/Tests/UnitTests/Media+PublicAPITests.swift
+++ b/Tests/UnitTests/Media+PublicAPITests.swift
@@ -42,7 +42,7 @@ class MediaPublicAPITests: XCTestCase {
         let expectation = XCTestExpectation(description: "createTracker should dispatch createTracker request an event")
         expectation.assertForOverFulfill = true
 
-        EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(type: MediaConstants.Media.EVENT_TYPE, source: MediaConstants.Media.EVENT_SOURCE_TRACKER_REQUEST) { event in
+        EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(type: MediaConstants.Media.EVENT_TYPE, source: MediaConstants.Media.EVENT_SOURCE_CREATE_TRACKER) { event in
             let eventData = event.data
             let trackerId = eventData?[MediaConstants.Tracker.ID] as? String
             let trackerConfig = eventData?[MediaConstants.Tracker.EVENT_PARAM] as? [String: Any]
@@ -64,7 +64,7 @@ class MediaPublicAPITests: XCTestCase {
         let expectation = XCTestExpectation(description: "createTracker should dispatch createTracker request an event")
         expectation.assertForOverFulfill = true
 
-        EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(type: MediaConstants.Media.EVENT_TYPE, source: MediaConstants.Media.EVENT_SOURCE_TRACKER_REQUEST) { event in
+        EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(type: MediaConstants.Media.EVENT_TYPE, source: MediaConstants.Media.EVENT_SOURCE_CREATE_TRACKER) { event in
             let eventData = event.data
             let trackerId = eventData?[MediaConstants.Tracker.ID] as? String
             let trackerConfig = eventData?[MediaConstants.Tracker.EVENT_PARAM] as? [String: Any]

--- a/Tests/UnitTests/MediaPublicTrackerTests.swift
+++ b/Tests/UnitTests/MediaPublicTrackerTests.swift
@@ -124,7 +124,7 @@ class MediaPublicTrackerTests: XCTestCase {
             capturedEvent = event
         }, config: nil)
 
-        XCTAssertEqual(MediaConstants.Media.EVENT_SOURCE_TRACKER_REQUEST, capturedEvent?.source)
+        XCTAssertEqual(MediaConstants.Media.EVENT_SOURCE_CREATE_TRACKER, capturedEvent?.source)
         XCTAssertEqual(MediaConstants.Media.EVENT_TYPE, capturedEvent?.type)
 
         let data = capturedEvent?.data
@@ -140,7 +140,7 @@ class MediaPublicTrackerTests: XCTestCase {
             capturedEvent = event
         }, config: Self.testConfig)
 
-        XCTAssertEqual(MediaConstants.Media.EVENT_SOURCE_TRACKER_REQUEST, capturedEvent?.source)
+        XCTAssertEqual(MediaConstants.Media.EVENT_SOURCE_CREATE_TRACKER, capturedEvent?.source)
         XCTAssertEqual(MediaConstants.Media.EVENT_TYPE, capturedEvent?.type)
 
         let data = capturedEvent?.data
@@ -160,7 +160,7 @@ class MediaPublicTrackerTests: XCTestCase {
             capturedEvent = event
         }, config: Self.testConfig)
 
-        XCTAssertEqual(MediaConstants.Media.EVENT_SOURCE_TRACKER_REQUEST, capturedEvent?.source)
+        XCTAssertEqual(MediaConstants.Media.EVENT_SOURCE_CREATE_TRACKER, capturedEvent?.source)
         XCTAssertEqual(MediaConstants.Media.EVENT_TYPE, capturedEvent?.type)
 
         let trackerId = capturedEvent?.trackerId

--- a/Tests/UnitTests/MediaRealTimeSessionTests.swift
+++ b/Tests/UnitTests/MediaRealTimeSessionTests.swift
@@ -494,8 +494,7 @@ class MediaRealTimeSessionTests: XCTestCase {
         XCTAssertTrue(session.isSessionActive)
         XCTAssertEqual(session.mediaBackendSessionId, "testBackendSessionId")
         // 1 sessionCreated event and the 5 queued media events
-        XCTAssertEqual(6, dispatchedEvents.count)
-        assertSessionCreatedEvent(expectedTrackerSessionId: Self.trackerSessionId, expectedBackendSessionId: "testBackendSessionId", actualEvent: dispatchedEvents[0])
+        XCTAssertEqual(5, dispatchedEvents.count)
         XCTAssertEqual(0, session.events.count)
     }
 
@@ -636,21 +635,6 @@ class MediaRealTimeSessionTests: XCTestCase {
     }
 
     // Test Helper
-
-    private func assertSessionCreatedEvent(expectedTrackerSessionId: String, expectedBackendSessionId: String, actualEvent: Event) {
-        XCTAssertEqual("Media::SessionCreated", actualEvent.name)
-        XCTAssertEqual("com.adobe.eventtype.edgemedia", actualEvent.type)
-        XCTAssertEqual("com.adobe.eventsource.edgemedia.sessioncreated", actualEvent.source)
-
-        guard let data = actualEvent.data else {
-            XCTFail("Event data cannot be null for Media::SessionCreated event")
-            return
-        }
-
-        XCTAssertEqual(expectedBackendSessionId, data["mediaservice.sessionid"] as? String ?? "")
-        XCTAssertEqual(expectedTrackerSessionId, data["sessionid"] as? String ?? "")
-
-    }
 
     private func assertBackendSessionId(expectedBackendSessionId: String, actualEvent: Event) {
         guard let eventData = actualEvent.data else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove the session created event dispatched when a new MediaSession is created. A new MediaSession is created when handling the `media-analytics:new-session` event dispatched from the Edge Extension. As the session created event dispatched from Edge Media is similar to the Edge event, it is not needed and is being removed. 

Updates the event source strings by removing `edgeMedia` from the strings so they are in line with event source strings of other extensions and renames requestTracker to createTracker.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
