### PR TITLE
Refactor MediaSession functions to remove session end closure

### DIFF
--- a/Sources/MediaEventProcessing.swift
+++ b/Sources/MediaEventProcessing.swift
@@ -15,11 +15,8 @@ import Foundation
 protocol MediaEventProcessing {
 
     /// Creates a new `session` and return its `sessionId`.
-    /// - Parameters:
-    ///    - trackerConfig: The tracker configuration.
-    ///    - trackerSessionId: A `UUID` string representing tracker session ID which can used be for debugging.
     /// - Returns: Unique SessionId for the session.
-    func createSession(trackerConfig: [String: Any], trackerSessionId: String?) -> String?
+    func createSession() -> String
 
     /// Process the Media Session with id `sessionId`
     ///

--- a/Sources/MediaEventProcessor.swift
+++ b/Sources/MediaEventProcessor.swift
@@ -39,13 +39,10 @@ class MediaEventProcessor: MediaEventProcessing {
     }
 
     /// Creates session with provided tracker configuration
-    /// - Parameters:
-    ///    - trackerConfig: tracker configuration.
-    ///    - trackerSessionId: A `UUID` string representing tracker session ID which can be used for debugging.
-    func createSession(trackerConfig: [String: Any], trackerSessionId: String?) -> String? {
+    func createSession() -> String {
         dispatchQueue.sync {
             let sessionId = uuid
-            let session = MediaRealTimeSession(id: sessionId, trackerSessionId: trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: dispatcher)
+            let session = MediaRealTimeSession(id: sessionId, state: mediaState, dispatcher: dispatcher)
 
             mediaSessions[sessionId] = session
             Log.trace(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - Created a new session (\(sessionId))")

--- a/Sources/MediaEventProcessor.swift
+++ b/Sources/MediaEventProcessor.swift
@@ -79,12 +79,8 @@ class MediaEventProcessor: MediaEventProcessing {
                 return
             }
 
-            session.end {
-                self.mediaSessions.removeValue(forKey: sessionId)
-                Log.trace(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - Successfully ended media session (\(sessionId))")
-            }
-
-            Log.trace(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - Scheduled end for media session (\(sessionId))")
+            session.end()
+            self.mediaSessions.forEach(self.removeInactiveSession)
         }
     }
 
@@ -100,7 +96,9 @@ class MediaEventProcessor: MediaEventProcessing {
     func updateMediaState(configurationSharedStateData: [String: Any]?) {
         dispatchQueue.async {
             self.mediaState.updateConfigurationSharedState(configurationSharedStateData)
-            self.mediaSessions.forEach { sessionId, _ in self.notifyMediaStateUpdate(sessionId: sessionId) }
+            self.mediaSessions.forEach { _, session in
+                session.handleMediaStateUpdate()
+            }
         }
     }
 
@@ -110,7 +108,11 @@ class MediaEventProcessor: MediaEventProcessing {
     ///  - backendSessionId: UUID `String` returned by the backend.
     func notifyBackendSessionId(requestEventId: String, backendSessionId: String?) {
         dispatchQueue.async {
-            self.mediaSessions.forEach { sessionId, _ in self.mediaSessions[sessionId]?.handleSessionUpdate(requestEventId: requestEventId, backendSessionId: backendSessionId) }
+            self.mediaSessions.forEach { sessionId, session in
+                session.handleSessionUpdate(requestEventId: requestEventId, backendSessionId: backendSessionId)
+                // Session may be aborted if session ID is invalid
+                self.removeInactiveSession(sessionId: sessionId, session: session)
+            }
         }
     }
 
@@ -120,20 +122,13 @@ class MediaEventProcessor: MediaEventProcessing {
     ///  - data: dictionary containing errors returned by the backend.
     func notifyErrorResponse(requestEventId: String, data: [String: Any?]) {
         dispatchQueue.async {
-            self.mediaSessions.forEach { sessionId, _ in self.mediaSessions[sessionId]?.handleErrorResponse(requestEventId: requestEventId, data: data) }
+            self.mediaSessions.forEach { sessionId, session in
+                session.handleErrorResponse(requestEventId: requestEventId, data: data)
+                // Session may be aborted on error
+                self.removeInactiveSession(sessionId: sessionId, session: session)
+            }
         }
 
-    }
-
-    /// Notify MediaState updates
-    /// - Parameter sessionId: Unique sessionId of session
-    private func notifyMediaStateUpdate(sessionId: String) {
-        guard let session = self.mediaSessions[sessionId] else {
-            Log.debug(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - Cannot notify states changes for media session (\(sessionId)). SessionId is invalid.")
-            return
-        }
-
-        session.handleMediaStateUpdate()
     }
 
     /// Abort the session `sessionId`.
@@ -145,11 +140,17 @@ class MediaEventProcessor: MediaEventProcessing {
             return
         }
 
-        session.abort {
-            self.mediaSessions.removeValue(forKey: sessionId)
-            Log.trace(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - Successfully aborted media session (\(sessionId)).")
-        }
+        session.abort()
+        self.mediaSessions.removeValue(forKey: sessionId)
+    }
 
-        Log.trace(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - Scheduled abort for media session (\(sessionId).")
+    /// Remove the `MediaSession` from the `mediaSessions` dictionary if that session is not longer active.
+    ///  - Parameters:
+    ///    - sessionId the ID of the `MediaSession` used as the key in `mediaSessions` dictionary
+    ///    - session the `MediaSession` to remove if inactive
+    private func removeInactiveSession(sessionId: String, session: MediaSession) {
+        if !session.isSessionActive && session.getQueueSize() == 0 {
+            mediaSessions[sessionId] = nil
+        }
     }
 }

--- a/Sources/MediaSession.swift
+++ b/Sources/MediaSession.swift
@@ -23,18 +23,14 @@ class MediaSession {
     private(set) var dispatcher: ((_ event: Event) -> Void)?
 
     var isSessionActive: Bool
-    var trackerSessionId: String?
 
     /// Initializer for `MediaSession`
     /// - Parameters:
     ///    - id: Unique `MediaSession id`
-    ///    - trackerSessionId: A `UUID` string representing tracker session ID which can used be for debugging.
     ///    - mediaState: `MediaState` object
-    ///    - dispatchQueue: `DispatchQueue` used for handling response after processing `MediaHit`
     ///    - dispather: A closure used for dispatching `Event`
-    init(id: String, trackerSessionId: String?, state: MediaState, dispatchQueue: DispatchQueue, dispatcher: ((_ event: Event) -> Void)?) {
+    init(id: String, state: MediaState, dispatcher: ((_ event: Event) -> Void)?) {
         self.id = id
-        self.trackerSessionId = trackerSessionId
         self.state = state
         self.dispatcher = dispatcher
         isSessionActive = true

--- a/Sources/MediaSession.swift
+++ b/Sources/MediaSession.swift
@@ -21,8 +21,8 @@ class MediaSession {
     private(set) var id: String
     private(set) var state: MediaState
     private(set) var dispatcher: ((_ event: Event) -> Void)?
+
     var isSessionActive: Bool
-    var sessionEndHandler: (() -> Void)?
     var trackerSessionId: String?
 
     /// Initializer for `MediaSession`
@@ -52,29 +52,31 @@ class MediaSession {
     }
 
     /// Ends the session
-    /// - Parameter onsessionEnd: An optional closure that will be executed after successfully ending the session.
-    func end(onSessionEnd sessionEndHandler: (() -> Void)? = nil) {
+    func end() {
         guard isSessionActive else {
             Log.debug(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - Failed to end session. Media Session (\(id)) is inactive")
             return
         }
 
-        self.sessionEndHandler = sessionEndHandler
         isSessionActive = false
         handleSessionEnd()
     }
 
     /// Aborts the session.
-    /// - Parameter onSessionEnd: An optional closure that will be executed after successfully aborting the session.
-    func abort(onSessionEnd sessionEndHandler: (() -> Void)? = nil) {
+    func abort() {
         guard isSessionActive else {
             Log.debug(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - Failed to abort session. Media Session (\(id)) is inactive")
             return
         }
 
-        self.sessionEndHandler = sessionEndHandler
         isSessionActive = false
         handleSessionAbort()
+    }
+
+    /// Get the number of queued `MediaXDMEvent`s
+    func getQueueSize() -> Int {
+        Log.warning(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - This function must be overwridden by the implementing class.")
+        return 0
     }
 
     /// Notifies MediaState updates

--- a/Sources/MediaXDMEventGenerator.swift
+++ b/Sources/MediaXDMEventGenerator.swift
@@ -45,7 +45,7 @@ class  MediaXDMEventGenerator {
         self.refTS = refTS
         self.currentPlaybackState = .Init
         self.currentPlaybackStateStartRefTS = refTS
-        startTrackingSession(trackerSessionId: refEvent.sessionId)
+        startTrackingSession()
     }
 
     func processSessionStart(forceResume: Bool = false) {
@@ -131,7 +131,7 @@ class  MediaXDMEventGenerator {
         currentPlaybackStateStartRefTS = refTS
 
         lastReportedQoe = nil
-        startTrackingSession(trackerSessionId: refEvent.sessionId)
+        startTrackingSession()
         processSessionStart(forceResume: true)
 
         if mediaContext.chapterInfo != nil {
@@ -211,16 +211,10 @@ class  MediaXDMEventGenerator {
     }
 
     /// Signals event processor to start a new media session.
-    ///    - Parameter trackerSessionId: A `UUID` string representing tracker session ID which can used be for debugging.
-    private func startTrackingSession(trackerSessionId: String?) {
-        guard let sessionId = mediaEventProcessor.createSession(trackerConfig: trackerConfig, trackerSessionId: trackerSessionId) else {
-            Log.debug(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - Unable to create a tracking session.")
-            isTracking = false
-            return
-        }
-        self.sessionId = sessionId
-        Log.debug(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - Started a new session with id (\(self.sessionId)).")
+    private func startTrackingSession() {
+        self.sessionId = mediaEventProcessor.createSession()
         isTracking = true
+        Log.debug(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - Started a new session with id (\(self.sessionId)).")
     }
 
     private func endTrackingSession() {

--- a/Tests/FunctionalTests/Utils/MediaEventProcessorSpy.swift
+++ b/Tests/FunctionalTests/Utils/MediaEventProcessorSpy.swift
@@ -27,8 +27,4 @@ class MediaEventProcessorSpy: MediaEventProcessor {
             session.handleSessionUpdate(requestEventId: sessionStartEvent.id.uuidString, backendSessionId: fakeBackendId)
         }
     }
-
-    func getTrackerSessionId(sessionId: String) -> String {
-        return mediaSessions[sessionId]?.trackerSessionId ?? ""
-    }
 }

--- a/Tests/UnitTests/MediaEventProcessorTests.swift
+++ b/Tests/UnitTests/MediaEventProcessorTests.swift
@@ -25,10 +25,7 @@ class MediaEventProcessorTests: XCTestCase {
 
         // test
         let mediaProcessor = MediaEventProcessor(dispatcher: nil)
-        guard let sessionId = mediaProcessor.createSession(trackerConfig: emptytrackerConfig, trackerSessionId: Self.trackerSessionId) else {
-            XCTFail("Could not create session id")
-            return
-        }
+        let sessionId = mediaProcessor.createSession()
 
         // Assert
         XCTAssertNotNil(sessionId)
@@ -42,12 +39,9 @@ class MediaEventProcessorTests: XCTestCase {
 
         // Action
         let mediaProcessor = MediaEventProcessor(dispatcher: nil)
-        guard let sessionId = mediaProcessor.createSession(trackerConfig: emptytrackerConfig, trackerSessionId: Self.trackerSessionId) else {
-            XCTFail("Could not create session id")
-            return
-        }
+        let sessionId = mediaProcessor.createSession()
 
-        let mediaSessionSpy = MediaSessionSpy(id: sessionId, trackerSessionId: Self.trackerSessionId, state: MediaState(), dispatchQueue: DispatchQueue(label: "testMediaEventProcessor"), dispatcher: nil)
+        let mediaSessionSpy = MediaSessionSpy(id: sessionId, state: MediaState(), dispatcher: nil)
         mediaProcessor.mediaSessions[sessionId] = mediaSessionSpy
         mediaProcessor.processEvent(sessionId: sessionId, event: MediaXDMEvent(eventType: XDMMediaEventType.sessionStart, timestamp: Date(timeIntervalSince1970: 0), mediaCollection: XDMMediaCollection()))
         Thread.sleep(forTimeInterval: 0.25)
@@ -62,7 +56,7 @@ class MediaEventProcessorTests: XCTestCase {
     func testProcessEvent_invalidSessionId() {
         // setup
         let mediaProcessor = MediaEventProcessor(dispatcher: nil)
-        let mediaSessionSpy = MediaSessionSpy(id: "SessionID-1", trackerSessionId: Self.trackerSessionId, state: MediaState(), dispatchQueue: DispatchQueue(label: "testMediaEventProcessor"), dispatcher: nil)
+        let mediaSessionSpy = MediaSessionSpy(id: "SessionID-1", state: MediaState(), dispatcher: nil)
 
         // test
         mediaProcessor.processEvent(sessionId: "InvalidSessionID", event: MediaXDMEvent(eventType: XDMMediaEventType.sessionStart, timestamp: Date(timeIntervalSince1970: 0), mediaCollection: XDMMediaCollection()))
@@ -81,16 +75,13 @@ class MediaEventProcessorTests: XCTestCase {
 
         // test
         let mediaProcessor = MediaEventProcessor(dispatcher: nil)
-        guard let sessionId = mediaProcessor.createSession(trackerConfig: emptytrackerConfig, trackerSessionId: Self.trackerSessionId) else {
-            XCTFail("Could not create session id")
-            return
-        }
+        let sessionId = mediaProcessor.createSession()
 
         // Assert
         XCTAssertNotNil(sessionId)
         XCTAssertTrue(mediaProcessor.mediaSessions.keys.contains(sessionId))
         XCTAssertNotNil(mediaProcessor.mediaSessions[sessionId])
-        let mediaSessionSpy = MediaSessionSpy(id: sessionId, trackerSessionId: Self.trackerSessionId, state: MediaState(), dispatchQueue: DispatchQueue(label: "testMediaEventProcessor"), dispatcher: nil)
+        let mediaSessionSpy = MediaSessionSpy(id: sessionId, state: MediaState(), dispatcher: nil)
         mediaProcessor.mediaSessions[sessionId] = mediaSessionSpy
         mediaProcessor.endSession(sessionId: sessionId)
         Thread.sleep(forTimeInterval: 0.25)
@@ -104,7 +95,7 @@ class MediaEventProcessorTests: XCTestCase {
     func testEndSession_invalidSessionId() {
         // setup
         let mediaProcessor = MediaEventProcessor(dispatcher: nil)
-        let mediaSessionSpy = MediaSessionSpy(id: "SessionID-1", trackerSessionId: Self.trackerSessionId, state: MediaState(), dispatchQueue: DispatchQueue(label: "testMediaEventProcessor"), dispatcher: nil)
+        let mediaSessionSpy = MediaSessionSpy(id: "SessionID-1", state: MediaState(), dispatcher: nil)
 
         // test
         mediaProcessor.endSession(sessionId: "InvalidSessionID")
@@ -122,14 +113,8 @@ class MediaEventProcessorTests: XCTestCase {
 
         // test
         let mediaProcessor = MediaEventProcessor(dispatcher: nil)
-        guard let sessionId1 = mediaProcessor.createSession(trackerConfig: emptytrackerConfig, trackerSessionId: Self.trackerSessionId) else {
-            XCTFail("Could not create session id")
-            return
-        }
-        guard let sessionId2 = mediaProcessor.createSession(trackerConfig: emptytrackerConfig, trackerSessionId: Self.trackerSessionId) else {
-            XCTFail("Could not create session id")
-            return
-        }
+        let sessionId1 = mediaProcessor.createSession()
+        let sessionId2 = mediaProcessor.createSession()
 
         // Assert
         XCTAssertNotNil(sessionId1)
@@ -139,8 +124,8 @@ class MediaEventProcessorTests: XCTestCase {
         XCTAssertNotNil(mediaProcessor.mediaSessions[sessionId1])
         XCTAssertNotNil(mediaProcessor.mediaSessions[sessionId2])
 
-        let mediaSessionSpy1 = MediaSessionSpy(id: sessionId1, trackerSessionId: Self.trackerSessionId, state: MediaState(), dispatchQueue: DispatchQueue(label: "testMediaEventProcessor"), dispatcher: nil)
-        let mediaSessionSpy2 = MediaSessionSpy(id: sessionId2, trackerSessionId: Self.trackerSessionId, state: MediaState(), dispatchQueue: DispatchQueue(label: "testMediaEventProcessor"), dispatcher: nil)
+        let mediaSessionSpy1 = MediaSessionSpy(id: sessionId1, state: MediaState(), dispatcher: nil)
+        let mediaSessionSpy2 = MediaSessionSpy(id: sessionId2, state: MediaState(), dispatcher: nil)
         mediaProcessor.mediaSessions[sessionId1] = mediaSessionSpy1
         mediaProcessor.mediaSessions[sessionId2] = mediaSessionSpy2
 
@@ -159,8 +144,8 @@ class MediaEventProcessorTests: XCTestCase {
         // setup
         let mediaProcessor = MediaEventProcessor(dispatcher: nil)
 
-        let mediaSessionSpy1 = MediaSessionSpy(id: "sessionId1", trackerSessionId: Self.trackerSessionId, state: MediaState(), dispatchQueue: DispatchQueue(label: "testMediaEventProcessor"), dispatcher: nil)
-        let mediaSessionSpy2 = MediaSessionSpy(id: "SessionId2", trackerSessionId: Self.trackerSessionId, state: MediaState(), dispatchQueue: DispatchQueue(label: "testMediaEventProcessor"), dispatcher: nil)
+        let mediaSessionSpy1 = MediaSessionSpy(id: "sessionId1", state: MediaState(), dispatcher: nil)
+        let mediaSessionSpy2 = MediaSessionSpy(id: "SessionId2", state: MediaState(), dispatcher: nil)
 
         mediaProcessor.mediaSessions["sessionId2"] = mediaSessionSpy2
 
@@ -180,17 +165,14 @@ class MediaEventProcessorTests: XCTestCase {
 
         // test
         let mediaProcessor = MediaEventProcessor(dispatcher: nil)
-        guard let sessionId = mediaProcessor.createSession(trackerConfig: emptytrackerConfig, trackerSessionId: Self.trackerSessionId) else {
-            XCTFail("Could not create session id")
-            return
-        }
+        let sessionId = mediaProcessor.createSession()
 
         // Assert
         XCTAssertNotNil(sessionId)
         XCTAssertTrue(mediaProcessor.mediaSessions.keys.contains(sessionId))
         XCTAssertNotNil(mediaProcessor.mediaSessions[sessionId])
 
-        let mediaSessionSpy = MediaSessionSpy(id: sessionId, trackerSessionId: Self.trackerSessionId, state: MediaState(), dispatchQueue: DispatchQueue(label: "testMediaEventProcessor"), dispatcher: nil)
+        let mediaSessionSpy = MediaSessionSpy(id: sessionId, state: MediaState(), dispatcher: nil)
         mediaProcessor.mediaSessions[sessionId] = mediaSessionSpy
         mediaProcessor.notifyBackendSessionId(requestEventId: "testRequestEventId", backendSessionId: "testSessionId")
         Thread.sleep(forTimeInterval: 0.25)
@@ -207,17 +189,14 @@ class MediaEventProcessorTests: XCTestCase {
 
         // test
         let mediaProcessor = MediaEventProcessor(dispatcher: nil)
-        guard let sessionId = mediaProcessor.createSession(trackerConfig: emptytrackerConfig, trackerSessionId: Self.trackerSessionId) else {
-            XCTFail("Could not create session id")
-            return
-        }
+        let sessionId = mediaProcessor.createSession()
 
         // Assert
         XCTAssertNotNil(sessionId)
         XCTAssertTrue(mediaProcessor.mediaSessions.keys.contains(sessionId))
         XCTAssertNotNil(mediaProcessor.mediaSessions[sessionId])
 
-        let mediaSessionSpy = MediaSessionSpy(id: sessionId, trackerSessionId: Self.trackerSessionId, state: MediaState(), dispatchQueue: DispatchQueue(label: "testMediaEventProcessor"), dispatcher: nil)
+        let mediaSessionSpy = MediaSessionSpy(id: sessionId, state: MediaState(), dispatcher: nil)
         mediaProcessor.mediaSessions[sessionId] = mediaSessionSpy
         mediaProcessor.notifyErrorResponse(requestEventId: "testRequestEventId", data: ["error1": "errorMsg"])
         Thread.sleep(forTimeInterval: 0.25)

--- a/Tests/UnitTests/MediaRealTimeSessionTests.swift
+++ b/Tests/UnitTests/MediaRealTimeSessionTests.swift
@@ -70,7 +70,7 @@ class MediaRealTimeSessionTests: XCTestCase {
 
         // verify
         XCTAssertEqual(0, dispatchedEvents.count)
-        XCTAssertEqual(3, session.events.count)
+        XCTAssertEqual(3, session.getQueueSize())
     }
 
     func testQueueMediaEvents_withoutPlayerNameConfig_doesNotDispatchEvent() {
@@ -87,7 +87,7 @@ class MediaRealTimeSessionTests: XCTestCase {
 
         // verify
         XCTAssertEqual(0, dispatchedEvents.count)
-        XCTAssertEqual(3, session.events.count)
+        XCTAssertEqual(3, session.getQueueSize())
     }
 
     func testQueueSessionStart() {
@@ -130,7 +130,7 @@ class MediaRealTimeSessionTests: XCTestCase {
 
         // verify
         XCTAssertEqual(1, dispatchedEvents.count)
-        XCTAssertEqual(17, session.events.count)
+        XCTAssertEqual(17, session.getQueueSize())
         assertEventTypeAndPath(actualEvent: dispatchedEvents[0], expectedEventType: XDMMediaEventType.sessionStart.edgeEventType(), expectedPath: "/va/v1/sessionStart")
     }
 
@@ -146,7 +146,7 @@ class MediaRealTimeSessionTests: XCTestCase {
 
         // verify
         XCTAssertEqual(4, dispatchedEvents.count)
-        XCTAssertEqual(0, session.events.count)
+        XCTAssertEqual(0, session.getQueueSize())
         assertEventTypeAndPath(actualEvent: dispatchedEvents[0], expectedEventType: XDMMediaEventType.sessionStart.edgeEventType(), expectedPath: "/va/v1/sessionStart")
     }
 
@@ -181,7 +181,7 @@ class MediaRealTimeSessionTests: XCTestCase {
 
         // verify
         XCTAssertEqual(1, dispatchedEvents.count)
-        XCTAssertEqual(5, session.events.count)
+        XCTAssertEqual(5, session.getQueueSize())
         assertBackendSessionId(expectedBackendSessionId: "session1", actualEvent: dispatchedEvents[0])
         assertEventTypeAndPath(actualEvent: dispatchedEvents[0], expectedEventType: XDMMediaEventType.sessionStart.edgeEventType(), expectedPath: "/va/v1/sessionStart")
     }
@@ -495,7 +495,7 @@ class MediaRealTimeSessionTests: XCTestCase {
         XCTAssertEqual(session.mediaBackendSessionId, "testBackendSessionId")
         // 1 sessionCreated event and the 5 queued media events
         XCTAssertEqual(5, dispatchedEvents.count)
-        XCTAssertEqual(0, session.events.count)
+        XCTAssertEqual(0, session.getQueueSize())
     }
 
     func testHandleSessionUpdate_withDifferentEdgeRequestId_ignoresTheEventAndWaitsForBackendSessionIdToDispatchQueuedEvents() {
@@ -516,7 +516,7 @@ class MediaRealTimeSessionTests: XCTestCase {
 
         // verify
         XCTAssertTrue(session.isSessionActive)
-        XCTAssertEqual(5, session.events.count)
+        XCTAssertEqual(5, session.getQueueSize())
     }
 
     func testHandleSessionUpdate_withEmptyBackendId_abortsMediaSession() {
@@ -538,7 +538,7 @@ class MediaRealTimeSessionTests: XCTestCase {
         // verify
         XCTAssertFalse(session.isSessionActive)
         XCTAssertEqual(0, dispatchedEvents.count)
-        XCTAssertEqual(0, session.events.count)
+        XCTAssertEqual(0, session.getQueueSize())
     }
 
     func testHandleSessionUpdate_withNilBackendId_abortsMediaSession() {
@@ -560,7 +560,7 @@ class MediaRealTimeSessionTests: XCTestCase {
         // verify
         XCTAssertFalse(session.isSessionActive)
         XCTAssertEqual(0, dispatchedEvents.count)
-        XCTAssertEqual(0, session.events.count)
+        XCTAssertEqual(0, session.getQueueSize())
     }
 
     func testHandleErrorResponse_withVAEdge400Error_abortsSession() {
@@ -576,7 +576,7 @@ class MediaRealTimeSessionTests: XCTestCase {
 
         // verify
         XCTAssertEqual(0, dispatchedEvents.count)
-        XCTAssertEqual(0, session.events.count)
+        XCTAssertEqual(0, session.getQueueSize())
         XCTAssertFalse(session.isSessionActive)
     }
 
@@ -593,7 +593,7 @@ class MediaRealTimeSessionTests: XCTestCase {
 
         // verify
         XCTAssertEqual(0, dispatchedEvents.count)
-        XCTAssertEqual(0, session.events.count)
+        XCTAssertEqual(0, session.getQueueSize())
         XCTAssertFalse(session.isSessionActive)
     }
 
@@ -610,7 +610,7 @@ class MediaRealTimeSessionTests: XCTestCase {
 
         // verify
         XCTAssertEqual(0, dispatchedEvents.count)
-        XCTAssertEqual(1, session.events.count)
+        XCTAssertEqual(1, session.getQueueSize())
         XCTAssertTrue(session.isSessionActive)
     }
 
@@ -630,7 +630,7 @@ class MediaRealTimeSessionTests: XCTestCase {
 
         // verify
         XCTAssertEqual(0, dispatchedEvents.count)
-        XCTAssertEqual(1, session.events.count)
+        XCTAssertEqual(1, session.getQueueSize())
         XCTAssertTrue(session.isSessionActive)
     }
 

--- a/Tests/UnitTests/MediaRealTimeSessionTests.swift
+++ b/Tests/UnitTests/MediaRealTimeSessionTests.swift
@@ -42,23 +42,11 @@ class MediaRealTimeSessionTests: XCTestCase {
         dispatchedEvents.append(event)
     }
 
-    func testTrackerSessionId_isValidStringWhenSetValidStringOnCreateSession() {
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
-
-        XCTAssertEqual("testTrackerSessionId", session.trackerSessionId)
-    }
-
-    func testTrackerSessionId_isNilWhenSetNilOnCreateSession() {
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: nil, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
-
-        XCTAssertNil(session.trackerSessionId)
-    }
-
     func testQueueMediaEvents_withoutChannelConfig_doesNotDispatchEvent() {
         // setup
         mediaState.updateConfigurationSharedState([MediaConstants.Configuration.MEDIA_APP_VERSION: "testAppVersion",
                                                    MediaConstants.Configuration.MEDIA_PLAYER_NAME: "testPlayerName"])
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
         session.mediaBackendSessionId = "testBackendSessionId"
 
         // test
@@ -76,7 +64,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     func testQueueMediaEvents_withoutPlayerNameConfig_doesNotDispatchEvent() {
         // setup
         mediaState.updateConfigurationSharedState([MediaConstants.Configuration.MEDIA_CHANNEL: "testChannel", MediaConstants.Configuration.MEDIA_APP_VERSION: "testAppVersion"])
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // test
         session.queue(event: MediaXDMEvent(eventType: XDMMediaEventType.sessionStart, timestamp: getDateFormattedTimestampFor(1), mediaCollection: XDMDataHelper.getSessionStartData()))
@@ -93,7 +81,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     func testQueueSessionStart() {
         // setup
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // test
         session.queue(event: MediaXDMEvent(eventType: XDMMediaEventType.sessionStart, timestamp: getDateFormattedTimestampFor(1), mediaCollection: XDMDataHelper.getSessionStartData()))
@@ -106,7 +94,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     func testQueueMediaEvents_withoutBackendSessionId_doesNotDispatchEventsOtherThanSessionStart() {
         // setup
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // test
         session.queue(event: MediaXDMEvent(eventType: XDMMediaEventType.sessionStart, timestamp: getDateFormattedTimestampFor(1), mediaCollection: XDMMediaCollection()))
@@ -136,7 +124,7 @@ class MediaRealTimeSessionTests: XCTestCase {
 
     func testQueueMediaEvents_withoutBackendSessionId_dispatchesConsecutiveSessionStartEvents() {
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // test
         session.queue(event: MediaXDMEvent(eventType: XDMMediaEventType.sessionStart, timestamp: getDateFormattedTimestampFor(1), mediaCollection: XDMMediaCollection()))
@@ -153,7 +141,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     // The session start ping present at the top of the event queue will be dispatched but the other sessionStart events are blocked by low level events waiting for backendSessionId
     func testQueueMediaEvents_withoutBackendSessionId_dispatchesSessionStartEventAtTopOfEventQueue() {
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         var mediaCollection1 = XDMMediaCollection()
         mediaCollection1.sessionID = "session1"
@@ -189,7 +177,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     func testQueue_sessionComplete() {
         // setup
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake backendSessionId
         session.mediaBackendSessionId = "testBackendSessionId"
@@ -206,7 +194,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     func testQueue_sessionEnd() {
         // setup
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake backendSessionId
         session.mediaBackendSessionId = "testBackendSessionId"
@@ -223,7 +211,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     func testQueue_play() {
         // setup
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake backendSessionId
         session.mediaBackendSessionId = "testBackendSessionId"
@@ -240,7 +228,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     func testQueue_pause() {
         // setup
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake backendSessionId
         session.mediaBackendSessionId = "testBackendSessionId"
@@ -257,7 +245,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     func testQueue_ping() {
         // setup
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake backendSessionId
         session.mediaBackendSessionId = "testBackendSessionId"
@@ -273,7 +261,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     func testQueue_error() {
         // setup
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake backendSessionId
         session.mediaBackendSessionId = "testBackendSessionId"
@@ -290,7 +278,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     func testQueue_bufferStart() {
         // setup
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake backendSessionId
         session.mediaBackendSessionId = "testBackendSessionId"
@@ -307,7 +295,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     func testQueue_bitrateChange() {
         // setup
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake backendSessionId
         session.mediaBackendSessionId = "testBackendSessionId"
@@ -324,7 +312,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     func testQueue_adBreakStart() {
         // setup
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake backendSessionId
         session.mediaBackendSessionId = "testBackendSessionId"
@@ -341,7 +329,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     func testQueue_adBreakComplete() {
         // setup
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake backendSessionId
         session.mediaBackendSessionId = "testBackendSessionId"
@@ -358,7 +346,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     func testQueue_adStart() {
         // setup
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake backendSessionId
         session.mediaBackendSessionId = "testBackendSessionId"
@@ -375,7 +363,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     func testQueue_adSkip() {
         // setup
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake backendSessionId
         session.mediaBackendSessionId = "testBackendSessionId"
@@ -392,7 +380,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     func testQueue_adComplete() {
         // setup
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake backendSessionId
         session.mediaBackendSessionId = "testBackendSessionId"
@@ -409,7 +397,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     func testQueue_chapterSkip() {
         // setup
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake backendSessionId
         session.mediaBackendSessionId = "testBackendSessionId"
@@ -426,7 +414,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     func testQueue_chapterStart() {
         // setup
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake backendSessionId
         session.mediaBackendSessionId = "testBackendSessionId"
@@ -443,7 +431,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     func testQueue_chapterComplete() {
         // setup
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake backendSessionId
         session.mediaBackendSessionId = "testBackendSessionId"
@@ -460,7 +448,7 @@ class MediaRealTimeSessionTests: XCTestCase {
     func testQueue_statesUpdate() {
         // setup
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake backendSessionId
         session.mediaBackendSessionId = "testBackendSessionId"
@@ -476,7 +464,7 @@ class MediaRealTimeSessionTests: XCTestCase {
 
     func testHandleSessionUpdate_updatesBackendSessionIdAndDispatchesEvents() {
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake sessionStartEdgeRequestId
         session.sessionStartEdgeRequestId = "testSessionStartEdgeRequestId"
@@ -500,7 +488,7 @@ class MediaRealTimeSessionTests: XCTestCase {
 
     func testHandleSessionUpdate_withDifferentEdgeRequestId_ignoresTheEventAndWaitsForBackendSessionIdToDispatchQueuedEvents() {
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake sessionStartEdgeRequestId
         session.sessionStartEdgeRequestId = "testSessionStartEdgeRequestId"
@@ -521,7 +509,7 @@ class MediaRealTimeSessionTests: XCTestCase {
 
     func testHandleSessionUpdate_withEmptyBackendId_abortsMediaSession() {
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake sessionStartEdgeRequestId
         session.sessionStartEdgeRequestId = "testSessionStartEdgeRequestId"
@@ -543,7 +531,7 @@ class MediaRealTimeSessionTests: XCTestCase {
 
     func testHandleSessionUpdate_withNilBackendId_abortsMediaSession() {
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake sessionStartEdgeRequestId
         session.sessionStartEdgeRequestId = "testSessionStartEdgeRequestId"
@@ -565,7 +553,7 @@ class MediaRealTimeSessionTests: XCTestCase {
 
     func testHandleErrorResponse_withVAEdge400Error_abortsSession() {
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake sessionStartEdgeRequestId
         session.sessionStartEdgeRequestId = "testSessionStartEdgeRequestId"
@@ -582,7 +570,7 @@ class MediaRealTimeSessionTests: XCTestCase {
 
     func testHandleErrorResponse_withExtraFieldsInErrorData_abortsSession() {
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake sessionStartEdgeRequestId
         session.sessionStartEdgeRequestId = "testSessionStartEdgeRequestId"
@@ -599,7 +587,7 @@ class MediaRealTimeSessionTests: XCTestCase {
 
     func testHandleErrorResponse_withDifferentEdgeRequestIdAndValidError_doesNotAbortSession() {
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake sessionStartEdgeRequestId
         session.sessionStartEdgeRequestId = "testSessionStartEdgeRequestId"
@@ -616,7 +604,7 @@ class MediaRealTimeSessionTests: XCTestCase {
 
     func testHandleErrorResponse_withInvalidErrorData_doesNotAbortSession() {
         mediaState.updateConfigurationSharedState(config)
-        let session = MediaRealTimeSession(id: "testId", trackerSessionId: Self.trackerSessionId, state: mediaState, dispatchQueue: dispatchQueue, dispatcher: fakeDispatcher)
+        let session = MediaRealTimeSession(id: "testId", state: mediaState, dispatcher: fakeDispatcher)
 
         // set fake sessionStartEdgeRequestId
         session.sessionStartEdgeRequestId = "testSessionStartEdgeRequestId"

--- a/Tests/UnitTests/Utils/FakeMediaEventProcessor.swift
+++ b/Tests/UnitTests/Utils/FakeMediaEventProcessor.swift
@@ -32,16 +32,13 @@ class FakeMediaEventProcessor: MediaEventProcessor {
         super.init(dispatcher: dispatcher)
     }
 
-    override func createSession(trackerConfig: [String: Any], trackerSessionId: String?) -> String? {
+    override func createSession() -> String {
         isSessionStartCalled = true
         var intSessionId = (Int(currentSessionId) ?? 0)
         intSessionId += 1
         currentSessionId = "\(intSessionId)"
         processedEvents[currentSessionId] = []
-        // for testing failed session creation
-        if let forcedFail = trackerConfig["testFail"] as? Bool, forcedFail == true {
-            return nil
-        }
+
         return currentSessionId
     }
 

--- a/Tests/UnitTests/Utils/MediaSessionSpy.swift
+++ b/Tests/UnitTests/Utils/MediaSessionSpy.swift
@@ -28,12 +28,10 @@ class MediaSessionSpy: MediaSession {
 
     override func handleSessionEnd() {
         hasSessionEndCalled = true
-        sessionEndHandler?()
     }
 
     override func handleSessionAbort() {
         hasSesionAbortCalled = true
-        sessionEndHandler?()
     }
 
     override func handleQueueEvent(_ event: MediaXDMEvent) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Refactor MediaSession, MediaRealTimeSession, and MediaEventProcessor to bring implementation in line with Android implementation.

Remove "sessionEndHandler" closure from Media Session and replace with better logging in MediaRealTimeSession and a bulk remove remove function in MediaEventProcessor to remove sessions which are not active and have no queued events.  Adds `getQueueSize()` function to MediaSession to get the current queue size, which is used by MediaEventProcessor, along with the existing `isMediaSessionActive` to determine if a session can be removed from the processor.

Removes trackerSessionId and dispatchQueue from MediaSession as they are not used. 
Removes trackerSessionId and trackerConfig from MediaEventProcessor.createSession() as they are not used.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
