### PR TITLE
Use EventType and EventSource from Core development branch

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .library(name: "AEPEdgeMedia", targets: ["AEPEdgeMedia"])
     ],
     dependencies: [
-        .package(url: "https://github.com/adobe/aepsdk-core-ios.git", .upToNextMajor(from: "3.7.0")),
+        .package(url: "https://github.com/adobe/aepsdk-core-ios.git", .branch("dev-v3.9.0")),
         .package(url: "https://github.com/adobe/aepsdk-edge-ios.git", .upToNextMajor(from: "1.6.0"))
     ],
     targets: [

--- a/Podfile
+++ b/Podfile
@@ -9,40 +9,40 @@ project 'AEPEdgeMedia.xcodeproj'
 pod 'SwiftLint', '0.44.0'
 
 target 'AEPEdgeMedia' do
-  pod 'AEPCore'
-  pod 'AEPServices'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v3.9.0'
+  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v3.9.0'
 end
 
 target 'UnitTests' do
-  pod 'AEPCore'
-  pod 'AEPServices'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v3.9.0'
+  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v3.9.0'
 end
 
 target 'FunctionalTests' do
-  pod 'AEPCore'
-  pod 'AEPServices'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v3.9.0'
+  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v3.9.0'
 end
 
 target 'IntegrationTests' do
-  pod 'AEPCore'
-  pod 'AEPServices'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v3.9.0'
+  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v3.9.0'
   pod 'AEPEdge'
   pod 'AEPEdgeIdentity'
 end
 
 target 'TestAppiOS' do
-  pod 'AEPCore'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v3.9.0'
   pod 'AEPEdge'
   pod 'AEPEdgeIdentity'
   pod 'AEPAssurance'
-  pod 'AEPServices'
+  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v3.9.0'
 end
 
 target 'TestApptvOS' do
-  pod 'AEPCore'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v3.9.0'
   pod 'AEPEdge'
   pod 'AEPEdgeIdentity'
-  pod 'AEPServices'
+  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v3.9.0'
 end
 
 post_install do |pi|

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,45 +2,59 @@ PODS:
   - AEPAssurance (3.0.1):
     - AEPCore (>= 3.1.0)
     - AEPServices (>= 3.1.0)
-  - AEPCore (3.7.4):
-    - AEPRulesEngine (>= 1.1.0)
-    - AEPServices (>= 3.7.4)
+  - AEPCore (3.8.2):
+    - AEPRulesEngine (>= 1.2.2)
+    - AEPServices (>= 3.8.2)
   - AEPEdge (1.6.0):
     - AEPCore (>= 3.7.0)
     - AEPEdgeIdentity (>= 1.2.0)
   - AEPEdgeIdentity (1.2.0):
     - AEPCore (>= 3.7.0)
-  - AEPRulesEngine (1.2.0)
-  - AEPServices (3.7.4)
+  - AEPRulesEngine (1.2.3)
+  - AEPServices (3.8.2)
   - SwiftLint (0.44.0)
 
 DEPENDENCIES:
   - AEPAssurance
-  - AEPCore
+  - AEPCore (from `https://github.com/adobe/aepsdk-core-ios.git`, branch `dev-v3.9.0`)
   - AEPEdge
   - AEPEdgeIdentity
-  - AEPServices
+  - AEPServices (from `https://github.com/adobe/aepsdk-core-ios.git`, branch `dev-v3.9.0`)
   - SwiftLint (= 0.44.0)
 
 SPEC REPOS:
   trunk:
     - AEPAssurance
-    - AEPCore
     - AEPEdge
     - AEPEdgeIdentity
     - AEPRulesEngine
-    - AEPServices
     - SwiftLint
+
+EXTERNAL SOURCES:
+  AEPCore:
+    :branch: dev-v3.9.0
+    :git: https://github.com/adobe/aepsdk-core-ios.git
+  AEPServices:
+    :branch: dev-v3.9.0
+    :git: https://github.com/adobe/aepsdk-core-ios.git
+
+CHECKOUT OPTIONS:
+  AEPCore:
+    :commit: 436ab7bb493e350e6648aed5eb4380fd4007cae7
+    :git: https://github.com/adobe/aepsdk-core-ios.git
+  AEPServices:
+    :commit: 436ab7bb493e350e6648aed5eb4380fd4007cae7
+    :git: https://github.com/adobe/aepsdk-core-ios.git
 
 SPEC CHECKSUMS:
   AEPAssurance: b25880cd4b14f22c61a1dce19807bd0ca0fe9b17
-  AEPCore: 4f2d6af62f492e87a6cc9cbf4c89ae6f0ea89d81
+  AEPCore: 52249635f856d5ee4b1042059cd5d55656f368d1
   AEPEdge: e4364a56d358c517f7d4cef87570ac4e7652d3a2
   AEPEdgeIdentity: 6bb2c1e62d48cdc988b4d492e8e6d563f0ced73d
-  AEPRulesEngine: 71228dfdac24c9ded09be13e3257a7eb22468ccc
-  AEPServices: 1c66ce125f9b3bbd46e42687b6929cd584bffdf4
+  AEPRulesEngine: f8d6eb0fa5a83d791f57867ed02f25fdf99894ec
+  AEPServices: 46df834256a392e67f5a24c894eff770bb05d678
   SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
 
-PODFILE CHECKSUM: 3f206d908541e1172789950622421137fd54bd8f
+PODFILE CHECKSUM: b467babdf7c9a27d1b7f0deefa5b7c97116e742c
 
 COCOAPODS: 1.11.3

--- a/Sources/Event+Media.swift
+++ b/Sources/Event+Media.swift
@@ -26,7 +26,7 @@ extension Event {
 
     /// Returns tracker config associated with EVENT_SOURCE_TRACKER_REQUEST Event
     var trackerConfig: [String: Any]? {
-        guard source == MediaConstants.Media.EVENT_SOURCE_CREATE_TRACKER else {
+        guard source == EventSource.createTracker else {
             return nil
         }
         return data?[MediaConstants.Tracker.EVENT_PARAM] as? [String: Any]

--- a/Sources/Media.swift
+++ b/Sources/Media.swift
@@ -43,11 +43,11 @@ public class Media: NSObject, Extension {
 
     /// Invoked when the Media extension has been registered by the `EventHub`
     public func onRegistered() {
-        registerListener(type: MediaConstants.Media.EVENT_TYPE, source: MediaConstants.Media.EVENT_SOURCE_CREATE_TRACKER, listener: handleMediaTrackerRequest)
-        registerListener(type: MediaConstants.Media.EVENT_TYPE, source: MediaConstants.Media.EVENT_SOURCE_TRACK_MEDIA, listener: handleMediaTrack)
+        registerListener(type: EventType.edgeMedia, source: EventSource.createTracker, listener: handleMediaTrackerRequest)
+        registerListener(type: EventType.edgeMedia, source: EventSource.trackMedia, listener: handleMediaTrack)
         registerListener(type: EventType.configuration, source: EventSource.responseContent, listener: handleConfigurationResponseEvent)
         registerListener(type: EventType.edge, source: MediaConstants.Media.EVENT_SOURCE_MEDIA_EDGE_SESSION, listener: handleMediaEdgeSessionDetails)
-        registerListener(type: EventType.edge, source: MediaConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESPONSE, listener: handleEdgeErrorResponse)
+        registerListener(type: EventType.edge, source: EventSource.errorResponseContent, listener: handleEdgeErrorResponse)
         registerListener(type: EventType.genericIdentity, source: EventSource.requestReset, listener: handleResetIdentitiesEvent)
     }
 

--- a/Sources/MediaConstants.swift
+++ b/Sources/MediaConstants.swift
@@ -28,14 +28,9 @@ internal extension MediaConstants {
     }
 
     enum Media {
-        static let EVENT_TYPE = "com.adobe.eventType.edgeMedia"
-        static let EVENT_SOURCE_CREATE_TRACKER = "com.adobe.eventSource.createTracker"
-        static let EVENT_SOURCE_TRACK_MEDIA = "com.adobe.eventSource.trackMedia"
         static let EVENT_NAME_CREATE_TRACKER = "Media::CreateTrackerRequest"
         static let EVENT_NAME_TRACK_MEDIA = "Media::TrackMedia"
         static let EVENT_SOURCE_MEDIA_EDGE_SESSION = "media-analytics:new-session"
-        static let EVENT_SOURCE_EDGE_ERROR_RESPONSE = "com.adobe.eventSource.errorResponseContent"
-
     }
 
     enum EventName {

--- a/Sources/MediaPublicTracker.swift
+++ b/Sources/MediaPublicTracker.swift
@@ -46,8 +46,8 @@ class MediaPublicTracker: MediaTracker {
             MediaConstants.Tracker.EVENT_PARAM: self.config ?? [:]
         ]
         let event = Event(name: MediaConstants.Media.EVENT_NAME_CREATE_TRACKER,
-                          type: MediaConstants.Media.EVENT_TYPE,
-                          source: MediaConstants.Media.EVENT_SOURCE_CREATE_TRACKER,
+                          type: EventType.edgeMedia,
+                          source: EventSource.createTracker,
                           data: eventData)
 
         dispatch?(event)
@@ -143,7 +143,7 @@ class MediaPublicTracker: MediaTracker {
         let ts = getCurrentTimeStamp()
         eventData[MediaConstants.Tracker.EVENT_TIMESTAMP] = ts
 
-        let event = Event(name: MediaConstants.Media.EVENT_NAME_TRACK_MEDIA, type: MediaConstants.Media.EVENT_TYPE, source: MediaConstants.Media.EVENT_SOURCE_TRACK_MEDIA, data: eventData)
+        let event = Event(name: MediaConstants.Media.EVENT_NAME_TRACK_MEDIA, type: EventType.edgeMedia, source: EventSource.trackMedia, data: eventData)
 
         dispatch?(event)
 

--- a/Tests/UnitTests/Media+PublicAPITests.swift
+++ b/Tests/UnitTests/Media+PublicAPITests.swift
@@ -42,7 +42,7 @@ class MediaPublicAPITests: XCTestCase {
         let expectation = XCTestExpectation(description: "createTracker should dispatch createTracker request an event")
         expectation.assertForOverFulfill = true
 
-        EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(type: MediaConstants.Media.EVENT_TYPE, source: MediaConstants.Media.EVENT_SOURCE_CREATE_TRACKER) { event in
+        EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(type: EventType.edgeMedia, source: EventSource.createTracker) { event in
             let eventData = event.data
             let trackerId = eventData?[MediaConstants.Tracker.ID] as? String
             let trackerConfig = eventData?[MediaConstants.Tracker.EVENT_PARAM] as? [String: Any]
@@ -64,7 +64,7 @@ class MediaPublicAPITests: XCTestCase {
         let expectation = XCTestExpectation(description: "createTracker should dispatch createTracker request an event")
         expectation.assertForOverFulfill = true
 
-        EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(type: MediaConstants.Media.EVENT_TYPE, source: MediaConstants.Media.EVENT_SOURCE_CREATE_TRACKER) { event in
+        EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(type: EventType.edgeMedia, source: EventSource.createTracker) { event in
             let eventData = event.data
             let trackerId = eventData?[MediaConstants.Tracker.ID] as? String
             let trackerConfig = eventData?[MediaConstants.Tracker.EVENT_PARAM] as? [String: Any]

--- a/Tests/UnitTests/MediaEventTrackerTests.swift
+++ b/Tests/UnitTests/MediaEventTrackerTests.swift
@@ -100,7 +100,7 @@ class MediaEventTrackerTests: XCTestCase {
         eventData?.removeValue(forKey: MediaConstants.Tracker.EVENT_NAME)
 
         let event = Event(name: "",
-                          type: MediaConstants.Media.EVENT_TYPE,
+                          type: EventType.edgeMedia,
                           source: MediaConstants.Media.EVENT_NAME_TRACK_MEDIA,
                           data: eventData)
         XCTAssertFalse(mediaTracker.track(event: event))
@@ -113,7 +113,7 @@ class MediaEventTrackerTests: XCTestCase {
         eventData?[MediaConstants.Tracker.EVENT_NAME] = "incorrect"
 
         let event = Event(name: "",
-                          type: MediaConstants.Media.EVENT_TYPE,
+                          type: EventType.edgeMedia,
                           source: MediaConstants.Media.EVENT_NAME_TRACK_MEDIA,
                           data: eventData)
         XCTAssertFalse(mediaTracker.track(event: event))
@@ -126,7 +126,7 @@ class MediaEventTrackerTests: XCTestCase {
         eventData?.removeValue(forKey: MediaConstants.Tracker.EVENT_TIMESTAMP)
 
         let event = Event(name: "",
-                          type: MediaConstants.Media.EVENT_TYPE,
+                          type: EventType.edgeMedia,
                           source: MediaConstants.Media.EVENT_NAME_TRACK_MEDIA,
                           data: eventData)
         XCTAssertFalse(mediaTracker.track(event: event))

--- a/Tests/UnitTests/MediaPublicTrackerTests.swift
+++ b/Tests/UnitTests/MediaPublicTrackerTests.swift
@@ -92,8 +92,8 @@ class MediaPublicTrackerTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(event.source, MediaConstants.Media.EVENT_SOURCE_TRACK_MEDIA)
-        XCTAssertEqual(event.type, MediaConstants.Media.EVENT_TYPE)
+        XCTAssertEqual(event.source, EventSource.trackMedia)
+        XCTAssertEqual(event.type, EventType.edgeMedia)
 
         let actualEventName = event.data?[MediaConstants.Tracker.EVENT_NAME] as? String ?? ""
         XCTAssertEqual(actualEventName, expectedEventName)
@@ -124,8 +124,8 @@ class MediaPublicTrackerTests: XCTestCase {
             capturedEvent = event
         }, config: nil)
 
-        XCTAssertEqual(MediaConstants.Media.EVENT_SOURCE_CREATE_TRACKER, capturedEvent?.source)
-        XCTAssertEqual(MediaConstants.Media.EVENT_TYPE, capturedEvent?.type)
+        XCTAssertEqual(EventSource.createTracker, capturedEvent?.source)
+        XCTAssertEqual(EventType.edgeMedia, capturedEvent?.type)
 
         let data = capturedEvent?.data
         XCTAssertFalse((data?[MediaConstants.Tracker.ID] as? String ?? "").isEmpty)
@@ -140,8 +140,8 @@ class MediaPublicTrackerTests: XCTestCase {
             capturedEvent = event
         }, config: Self.testConfig)
 
-        XCTAssertEqual(MediaConstants.Media.EVENT_SOURCE_CREATE_TRACKER, capturedEvent?.source)
-        XCTAssertEqual(MediaConstants.Media.EVENT_TYPE, capturedEvent?.type)
+        XCTAssertEqual(EventSource.createTracker, capturedEvent?.source)
+        XCTAssertEqual(EventType.edgeMedia, capturedEvent?.type)
 
         let data = capturedEvent?.data
         XCTAssertFalse((data?[MediaConstants.Tracker.ID] as? String ?? "").isEmpty)
@@ -160,8 +160,8 @@ class MediaPublicTrackerTests: XCTestCase {
             capturedEvent = event
         }, config: Self.testConfig)
 
-        XCTAssertEqual(MediaConstants.Media.EVENT_SOURCE_CREATE_TRACKER, capturedEvent?.source)
-        XCTAssertEqual(MediaConstants.Media.EVENT_TYPE, capturedEvent?.type)
+        XCTAssertEqual(EventSource.createTracker, capturedEvent?.source)
+        XCTAssertEqual(EventType.edgeMedia, capturedEvent?.type)
 
         let trackerId = capturedEvent?.trackerId
         XCTAssertFalse((trackerId ?? "").isEmpty)

--- a/Tests/UnitTests/MediaXDMEventGeneratorTests.swift
+++ b/Tests/UnitTests/MediaXDMEventGeneratorTests.swift
@@ -24,8 +24,8 @@ class MediaXDMEventGeneratorTests: XCTestCase {
     private var mockPlayhead = Int64(0)
     static let trackerSessionId = "clientSessionId"
     static let refEvent = Event(name: MediaConstants.Media.EVENT_NAME_TRACK_MEDIA,
-                                type: MediaConstants.Media.EVENT_TYPE,
-                                source: MediaConstants.Media.EVENT_SOURCE_TRACK_MEDIA,
+                                type: EventType.edgeMedia,
+                                source: EventSource.trackMedia,
                                 data: [MediaConstants.Tracker.SESSION_ID: trackerSessionId])
 
     override func setUp() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use EventType and EventSource from latest Mobile Core development branch of `dev-v3.9.0'. This development branch contains the Edge Media EventType and EventSources. 

After the release of AEPCore v3.9.0, will need to update Podfile and Package.swift to point to the released AEPCore version.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
