### PR TITLE
Rename MediaPublicTracker to MediaTrackerEventGenerator

### DIFF
--- a/AEPEdgeMedia.xcodeproj/project.pbxproj
+++ b/AEPEdgeMedia.xcodeproj/project.pbxproj
@@ -94,7 +94,7 @@
 		2EB040FE2894AE0600306323 /* MediaConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB040F52894AE0600306323 /* MediaConstants.swift */; };
 		2EB164EE289AF3B800089C83 /* MediaEventTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB164ED289AF3B800089C83 /* MediaEventTracking.swift */; };
 		2EB164EF289AF55800089C83 /* MediaTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EDFBD062899E3B400D22B25 /* MediaTracker.swift */; };
-		2EB164F0289AF56400089C83 /* MediaPublicTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EDFBD042899E36C00D22B25 /* MediaPublicTracker.swift */; };
+		2EB164F0289AF56400089C83 /* MediaTrackerEventGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EDFBD042899E36C00D22B25 /* MediaTrackerEventGenerator.swift */; };
 		2EB164F3289AF59C00089C83 /* MediaEventGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB164F2289AF59C00089C83 /* MediaEventGenerator.swift */; };
 		2EB164F5289AF63900089C83 /* MockExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB164F4289AF63900089C83 /* MockExtension.swift */; };
 		2EB164F7289AF6B900089C83 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB164F6289AF6B900089C83 /* TestHelpers.swift */; };
@@ -273,7 +273,7 @@
 		2EDFBCF82899E2F700D22B25 /* MediaConstants+Public.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MediaConstants+Public.swift"; sourceTree = "<group>"; };
 		2EDFBCF92899E2F700D22B25 /* MediaType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaType.swift; sourceTree = "<group>"; };
 		2EDFBCFA2899E2F700D22B25 /* Media+PublicAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Media+PublicAPI.swift"; sourceTree = "<group>"; };
-		2EDFBD042899E36C00D22B25 /* MediaPublicTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaPublicTracker.swift; sourceTree = "<group>"; };
+		2EDFBD042899E36C00D22B25 /* MediaTrackerEventGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaTrackerEventGenerator.swift; sourceTree = "<group>"; };
 		2EDFBD062899E3B400D22B25 /* MediaTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaTracker.swift; sourceTree = "<group>"; };
 		2EDFBD092899E3DF00D22B25 /* StateInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StateInfo.swift; sourceTree = "<group>"; };
 		2EDFBD0A2899E3DF00D22B25 /* AdInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdInfo.swift; sourceTree = "<group>"; };
@@ -489,7 +489,7 @@
 				2EB164ED289AF3B800089C83 /* MediaEventTracking.swift */,
 				2E37D38428D290CE00B782F8 /* MediaEventProcessing.swift */,
 				2E37D33C28CFDD7800B782F8 /* MediaEventProcessor.swift */,
-				2EDFBD042899E36C00D22B25 /* MediaPublicTracker.swift */,
+				2EDFBD042899E36C00D22B25 /* MediaTrackerEventGenerator.swift */,
 				2E37D34028CFE44400B782F8 /* MediaRealTimeSession.swift */,
 				2ED7125428ADA958006A83D0 /* MediaRule.swift */,
 				2ED7125628ADA958006A83D0 /* MediaRuleEngine.swift */,
@@ -1240,7 +1240,7 @@
 				2E37D33D28CFDD7800B782F8 /* MediaEventProcessor.swift in Sources */,
 				2E37D33F28CFDDF900B782F8 /* MediaSession.swift in Sources */,
 				2EB040FC2894AE0600306323 /* Double+Media.swift in Sources */,
-				2EB164F0289AF56400089C83 /* MediaPublicTracker.swift in Sources */,
+				2EB164F0289AF56400089C83 /* MediaTrackerEventGenerator.swift in Sources */,
 				2E37D38528D290CE00B782F8 /* MediaEventProcessing.swift in Sources */,
 				2ED7126528ADD665006A83D0 /* MediaState.swift in Sources */,
 				2EDFBD102899E3DF00D22B25 /* AdInfo.swift in Sources */,

--- a/Sources/MediaTrackerEventGenerator.swift
+++ b/Sources/MediaTrackerEventGenerator.swift
@@ -14,7 +14,7 @@ import AEPCore
 import AEPServices
 import Foundation
 
-class MediaPublicTracker: MediaTracker {
+class MediaTrackerEventGenerator: MediaTracker {
 
     private static let LOG_TAG = MediaConstants.LOG_TAG
     private static let CLASS_NAME = "MediaPublicTracker"

--- a/Sources/Public/Media+PublicAPI.swift
+++ b/Sources/Public/Media+PublicAPI.swift
@@ -30,7 +30,7 @@ import Foundation
     ///   - config: The configuration for `MediaTracker` instance.
     @objc(createTrackerWithConfig:)
     static func createTrackerWith(config: [String: Any]?) -> MediaTracker {
-        return MediaPublicTracker(dispatch: MobileCore.dispatch(event:), config: config)
+        return MediaTrackerEventGenerator(dispatch: MobileCore.dispatch(event:), config: config)
     }
 
     /// Creates an instance of `MediaInfo` to be used with `trackSessionStart` API.

--- a/Tests/TestHelpers/MediaEventGenerator.swift
+++ b/Tests/TestHelpers/MediaEventGenerator.swift
@@ -16,7 +16,7 @@ import XCTest
 
 class MediaEventGenerator: MediaTracker {
 
-    class MediaPublicTrackerMock: MediaPublicTracker {
+    class MediaPublicTrackerMock: MediaTrackerEventGenerator {
         var mockTimeStamp = TimeInterval(0)
         var mockCurrentPlayhead: Int = 0
 

--- a/Tests/UnitTests/MediaPublicTrackerTests.swift
+++ b/Tests/UnitTests/MediaPublicTrackerTests.swift
@@ -120,7 +120,7 @@ class MediaPublicTrackerTests: XCTestCase {
     // ==========================================================================
     func testCreateTracker() {
         var capturedEvent: Event?
-        _ = MediaPublicTracker(dispatch: {(event: Event) in
+        _ = MediaTrackerEventGenerator(dispatch: {(event: Event) in
             capturedEvent = event
         }, config: nil)
 
@@ -136,7 +136,7 @@ class MediaPublicTrackerTests: XCTestCase {
 
     func testCreateTrackerWithConfig() {
         var capturedEvent: Event?
-        _ = MediaPublicTracker(dispatch: {(event: Event) in
+        _ = MediaTrackerEventGenerator(dispatch: {(event: Event) in
             capturedEvent = event
         }, config: Self.testConfig)
 
@@ -156,7 +156,7 @@ class MediaPublicTrackerTests: XCTestCase {
 
     func testEventExtension_TrackerIdAndConfig() {
         var capturedEvent: Event?
-        _ = MediaPublicTracker(dispatch: {(event: Event) in
+        _ = MediaTrackerEventGenerator(dispatch: {(event: Event) in
             capturedEvent = event
         }, config: Self.testConfig)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Rename MediaPublicTracker to MediaTrackerEventGenerator as the name is more descriptive of the class' function and it matches the name used in Android implementation.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
